### PR TITLE
Minor swizzle fixes (saves 24 bytes)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "makefile.configureOnOpen": true,
+    "files.associations": {
+        "*.inc": "c",
+        "minimath.h": "c"
+    }
+}

--- a/fractal.c
+++ b/fractal.c
@@ -109,6 +109,7 @@ static uint64_t dl_draw_bitmap[] = {
 
 #define dl_draw_bitmap_cnt  (sizeof(dl_draw_bitmap) / sizeof(uint64_t))
 
+__attribute__((noinline))
 static void fracgen_draw(void)
 {
     int tbuf_offset = (framecount & 1) * BITMAP_WIDTH*BITMAP_HEIGHT/2;

--- a/mesh.c
+++ b/mesh.c
@@ -15,7 +15,7 @@ typedef struct {
 static float xangle = MM_PI/8;
 static float yangle = MM_PI/4;
 
-uint32_t mesh(void)
+static uint32_t mesh(void)
 {
     // Number of segments for the major (u) and minor (v) circles.
     const int numMajor = 32; // Segments along the torus' main circle.

--- a/tools/swizzle3.cpp
+++ b/tools/swizzle3.cpp
@@ -289,7 +289,7 @@ int main(int argc, char** argv) {
             ELFIO::section* sec = reader.sections[i];
             std::string sec_name = sec->get_name();
             // Filter out common metadata.
-            if (sec_name == ".symtab" || sec_name == ".strtab" || sec_name == ".shstrtab")
+            if (sec_name == ".symtab" || sec_name == ".strtab" || sec_name == ".shstrtab" || sec_name == ".comment" || sec_name == ".pdr")
                 continue;
             if (sec_name.find(".debug") == 0)
                 continue;


### PR DESCRIPTION
Though, the saving are a bit chaotic

 - ignore more metadata
 - Don't inline fractal_draw (seems to help)
 - hide mesh from swizzle